### PR TITLE
Add problem 01 solutions for multiples of 3 or 5

### DIFF
--- a/problems/01_multiples_of_3_or_5/multiples_of_3_or_5.cpp
+++ b/problems/01_multiples_of_3_or_5/multiples_of_3_or_5.cpp
@@ -1,0 +1,32 @@
+// multiples_of_3_or_5.cpp
+// Simple readable implementation; final print redacted.
+
+#include <cstdint>
+#include <iostream>
+
+static bool is_multiple_of_3_or_5(std::uint64_t n) {
+    return (n % 3 == 0) || (n % 5 == 0);
+}
+
+static std::uint64_t sum_scan(std::uint64_t limit) {
+    std::uint64_t total = 0;
+    for (std::uint64_t k = 1; k < limit; ++k) {
+        if (is_multiple_of_3_or_5(k)) {
+            total += k;
+        }
+    }
+    return total;
+}
+
+int main() {
+    const std::uint64_t limit = 1000;
+    const auto result = sum_scan(limit);
+    // std::cout << "Sum for " << limit << " = " << result << "\n"; // TODO: reveal locally
+    std::cout << "Sum for " << limit << " = <compute locally>\n";
+    // Example check: below 10 -> 23
+    if (sum_scan(10) != 23) {
+        return 1;
+    }
+    (void)result;
+    return 0;
+}

--- a/problems/01_multiples_of_3_or_5/multiples_of_3_or_5.py
+++ b/problems/01_multiples_of_3_or_5/multiples_of_3_or_5.py
@@ -1,0 +1,28 @@
+# multiples_of_3_or_5.py
+# Straightforward scan; final print redacted.
+
+
+def is_multiple_of_3_or_5(n: int) -> bool:
+    return n % 3 == 0 or n % 5 == 0
+
+
+def sum_scan(limit: int) -> int:
+    total = 0
+    for k in range(1, limit):  # exclusive upper bound
+        if is_multiple_of_3_or_5(k):
+            total += k
+    return total
+
+
+def main() -> None:
+    limit = 1000
+    result = sum_scan(limit)
+    # print(result)  # TODO: reveal locally
+    print(f"Sum for {limit} = <compute locally>")
+    # Example from the statement:
+    assert sum_scan(10) == 23
+    _ = result
+
+
+if __name__ == "__main__":
+    main()

--- a/problems/01_multiples_of_3_or_5/multiples_of_3_or_5_idiomatic.rs
+++ b/problems/01_multiples_of_3_or_5/multiples_of_3_or_5_idiomatic.rs
@@ -1,0 +1,57 @@
+// multiples_of_3_or_5_idiomatic.rs
+// O(1) solution using arithmetic series and inclusion–exclusion.
+// Keeps the final answer redacted per the "near-finish" rule.
+
+#[inline]
+fn gcd(mut a: u64, mut b: u64) -> u64 {
+    while b != 0 {
+        let r = a % b;
+        a = b;
+        b = r;
+    }
+    a
+}
+
+#[inline]
+fn lcm(a: u64, b: u64) -> u64 {
+    a / gcd(a, b) * b
+}
+
+/// Sum of all positive multiples of k strictly below `limit`.
+fn sum_of_multiples_below(limit: u64, k: u64) -> u128 {
+    assert!(k > 0, "k must be positive");
+    if limit <= 1 {
+        return 0;
+    }
+
+    let m = (limit - 1) / k; // m_k = floor((N-1)/k)
+    let m128 = m as u128;
+    let k128 = k as u128;
+    k128 * m128 * (m128 + 1) / 2 // k * m * (m + 1) / 2
+}
+
+fn sum_3_or_5(limit: u64) -> u128 {
+    let s3 = sum_of_multiples_below(limit, 3);
+    let s5 = sum_of_multiples_below(limit, 5);
+    let s15 = sum_of_multiples_below(limit, lcm(3, 5));
+    s3 + s5 - s15
+}
+
+fn main() {
+    const LIMIT: u64 = 1000;
+    let total = sum_3_or_5(LIMIT);
+    // println!("Answer: {}", total); // TODO: reveal locally
+    println!("S = S3 + S5 - S15  (evaluate locally)");
+    let _ = total; // keep the computation live without printing the answer
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn example_under_10() {
+        // Below 10 -> 23 (3 + 5 + 6 + 9)
+        assert_eq!(sum_3_or_5(10), 23);
+    }
+}

--- a/problems/01_multiples_of_3_or_5/multiples_of_3_or_5_simple.rs
+++ b/problems/01_multiples_of_3_or_5/multiples_of_3_or_5_simple.rs
@@ -1,0 +1,29 @@
+// multiples_of_3_or_5_simple.rs
+// Naive scan with clear comments (no spoiler: final print redacted).
+
+fn is_multiple_of_3_or_5(n: u64) -> bool {
+    // A number is a multiple of 3 or 5 if it divides evenly by 3 or 5.
+    n % 3 == 0 || n % 5 == 0
+}
+
+fn sum_multiples_scan(limit: u64) -> u64 {
+    // Sum all integers k with 1 <= k < limit that are multiples of 3 or 5.
+    let mut total: u64 = 0;
+    // The range 1..limit is exclusive on the right in Rust.
+    for k in 1..limit {
+        if is_multiple_of_3_or_5(k) {
+            total += k;
+        }
+    }
+    total
+}
+
+fn main() {
+    const LIMIT: u64 = 1000; // upper bound, exclusive
+    let result = sum_multiples_scan(LIMIT);
+    // println!("Sum for {} = {}", LIMIT, result); // TODO: reveal locally
+    println!("Sum for {} = <compute locally>", LIMIT);
+    // Sanity check using the example from the problem statement:
+    // Below 10, the multiples are 3, 5, 6, 9; they sum to 23.
+    assert_eq!(sum_multiples_scan(10), 23);
+}


### PR DESCRIPTION
## Summary
- add a direct Rust implementation for Project Euler problem 1 with placeholder output to respect the no-spoilers policy
- add an idiomatic Rust arithmetic-series solution plus unit test coverage
- provide matching C++ and Python reference implementations for the same problem

## Testing
- rustc --test problems/01_multiples_of_3_or_5/multiples_of_3_or_5_idiomatic.rs -o /tmp/mult_test && /tmp/mult_test
- g++ -std=c++17 -O2 -Wall -Wextra problems/01_multiples_of_3_or_5/multiples_of_3_or_5.cpp -o /tmp/mult && /tmp/mult
- python3 problems/01_multiples_of_3_or_5/multiples_of_3_or_5.py


------
https://chatgpt.com/codex/tasks/task_e_68e1693f1cb4832d90f563357db069ea