### PR TITLE
Add problem 06 sum square difference implementations

### DIFF
--- a/problems/06_sum_square_difference/sum_square_difference.cpp
+++ b/problems/06_sum_square_difference/sum_square_difference.cpp
@@ -1,0 +1,30 @@
+// sum_square_difference.cpp
+// Use closed forms; final print redacted.
+
+#include <cstdint>
+#include <iostream>
+
+static unsigned long long sum_to(unsigned long long n) {
+    return n * (n + 1) / 2ull;
+}
+
+static unsigned long long sum_of_squares(unsigned long long n) {
+    return n * (n + 1) * (2ull * n + 1) / 6ull;
+}
+
+static unsigned long long square(unsigned long long x) {
+    return x * x;
+}
+
+int main() {
+    const unsigned long long N = 100ull;
+    auto diff = square(sum_to(N)) - sum_of_squares(N);
+    // std::cout << diff << "\n"; // TODO: reveal locally
+    std::cout << "difference for 100 = <compute locally>\n";
+    // Statement check for n=10:
+    if (sum_of_squares(10) != 385ull) return 1;
+    if (square(sum_to(10)) != 3025ull) return 1;
+    if (square(sum_to(10)) - sum_of_squares(10) != (3025ull - 385ull)) return 1;
+    (void)diff;
+    return 0;
+}

--- a/problems/06_sum_square_difference/sum_square_difference.py
+++ b/problems/06_sum_square_difference/sum_square_difference.py
@@ -1,0 +1,34 @@
+# sum_square_difference.py
+# Closed-form formulas; final print redacted.
+
+
+def sum_to(n: int) -> int:
+    return n * (n + 1) // 2
+
+
+def sum_of_squares(n: int) -> int:
+    return n * (n + 1) * (2 * n + 1) // 6
+
+
+def square(x: int) -> int:
+    return x * x
+
+
+def difference(n: int) -> int:
+    return square(sum_to(n)) - sum_of_squares(n)
+
+
+def main() -> None:
+    n = 100
+    diff = difference(n)
+    # print(diff)  # TODO: reveal locally
+    print(f"difference for {n} = <compute locally>")
+    # Statement check:
+    assert sum_of_squares(10) == 385
+    assert square(sum_to(10)) == 3025
+    assert difference(10) == 3025 - 385
+    _ = diff
+
+
+if __name__ == "__main__":
+    main()

--- a/problems/06_sum_square_difference/sum_square_difference_idiomatic.rs
+++ b/problems/06_sum_square_difference/sum_square_difference_idiomatic.rs
@@ -1,0 +1,51 @@
+// sum_square_difference_idiomatic.rs
+// Algebraic simplification and helpers; final print redacted.
+
+#[inline]
+fn sum_to(n: u128) -> u128 {
+    n * (n + 1) / 2
+}
+
+#[inline]
+fn sum_of_squares(n: u128) -> u128 {
+    n * (n + 1) * (2 * n + 1) / 6
+}
+
+#[inline]
+fn square(x: u128) -> u128 {
+    x * x
+}
+
+/// difference(n) = (sum_{k=1}^n k)^2 - sum_{k=1}^n k^2
+pub fn difference(n: u128) -> u128 {
+    square(sum_to(n)) - sum_of_squares(n)
+}
+
+fn main() {
+    const N: u128 = 100;
+    let ans = difference(N);
+    // println!("Answer: {}", ans); // TODO: reveal locally
+    println!("D(n) = (n(n+1)/2)^2 - n(n+1)(2n+1)/6  at n=100 -> <compute locally>");
+    let _ = ans;
+    // Example from statement:
+    assert_eq!(difference(10), 3025 - 385);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tiny() {
+        assert_eq!(sum_to(1), 1);
+        assert_eq!(sum_of_squares(1), 1);
+        assert_eq!(difference(1), 0);
+    }
+
+    #[test]
+    fn example_10() {
+        assert_eq!(sum_to(10), 55);
+        assert_eq!(sum_of_squares(10), 385);
+        assert_eq!(difference(10), 3025 - 385);
+    }
+}

--- a/problems/06_sum_square_difference/sum_square_difference_simple.rs
+++ b/problems/06_sum_square_difference/sum_square_difference_simple.rs
@@ -1,0 +1,34 @@
+// sum_square_difference_simple.rs
+// Direct formulas with u128 arithmetic. Final print redacted.
+
+/// S(n) = 1 + 2 + ... + n
+fn sum_to(n: u128) -> u128 {
+    n * (n + 1) / 2
+}
+
+/// Q(n) = 1^2 + 2^2 + ... + n^2
+fn sum_of_squares(n: u128) -> u128 {
+    n * (n + 1) * (2 * n + 1) / 6
+}
+
+fn square(x: u128) -> u128 {
+    x * x
+}
+
+fn difference(n: u128) -> u128 {
+    let s = sum_to(n);
+    let q = sum_of_squares(n);
+    square(s) - q
+}
+
+fn main() {
+    const N: u128 = 100;
+    let d = difference(N);
+    // println!("difference for {} = {}", N, d); // TODO: reveal locally
+    println!("difference for {} = <compute locally>", N);
+    // Statement check for n=10:
+    assert_eq!(sum_of_squares(10), 385);
+    assert_eq!(square(sum_to(10)), 3025);
+    assert_eq!(difference(10), 3025 - 385);
+    let _ = d;
+}


### PR DESCRIPTION
## Summary
- add direct Rust implementation for the sum square difference formulas
- add idiomatic Rust version with inline helpers and regression tests
- mirror the solution in C++ and Python for problem 06

## Testing
- not run (explanatory snippets only)

------
https://chatgpt.com/codex/tasks/task_e_68e17fb27d24832d8629063162be6665